### PR TITLE
Added functionality to delete a previously published blog post

### DIFF
--- a/controllers/api/blogRoutes.js
+++ b/controllers/api/blogRoutes.js
@@ -24,4 +24,31 @@ router.post('/new-comment', async (req, res) => {
 	}
 });
 
+
+// Delete Post
+router.delete('/delete', async (req, res) => {
+	try {
+		postId = req.body.target;
+		const postData = await Post.findByPk(postId)
+
+		if (postData === null) {
+			console.log('No record found');
+			return;
+		} 
+
+		if (postData.user_id === req.session.user_id) {
+			const deletedPostData = await Post.destroy({
+				where: {
+					id: postData.id
+				}
+			});
+			res.status(202).json(deletedPostData);
+		} else {
+			res.status(401).json('You are not authorized to delete this post')
+		}
+	} catch (err) {
+		res.status(400).json(err);
+	}
+})
+
 module.exports = router;

--- a/controllers/api/blogRoutes.js
+++ b/controllers/api/blogRoutes.js
@@ -28,11 +28,12 @@ router.post('/new-comment', async (req, res) => {
 // Delete Post
 router.delete('/delete', async (req, res) => {
 	try {
-		postId = req.body.target;
+		postId = req.body.target; // When testing, send with target as the object property
 		const postData = await Post.findByPk(postId)
 
 		if (postData === null) {
 			console.log('No record found');
+			res.status(404).json("No record found")
 			return;
 		} 
 

--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -1,0 +1,22 @@
+const postContainer = document.querySelector('.post-container');
+
+const deletePost = async (event) => {
+	 if (event.target.matches('button') && event.target.name) {
+		// const currentTarget = event.currentTarget.getAttribute("name");
+	  	const target = parseInt(event.target.getAttribute("name"));
+	
+  		const response = await fetch('/api/blog/delete', {
+  			method: 'DELETE',
+  			body: JSON.stringify({ target }),
+  			headers: { 'Content-Type': 'application/json' },
+  		});
+
+  		if (response.ok) {
+  			document.location.reload();
+  		} else {
+  			alert(response.statusText);
+  		};
+	};
+}
+
+postContainer.addEventListener('click', deletePost)

--- a/views/dashboard.handlebars
+++ b/views/dashboard.handlebars
@@ -1,7 +1,7 @@
 {{#if logged_in}}
 
 {{#each posts as |post| }}
-{{> blog-post-preview}}
+{{> blog-post-preview-dashboard}}
 {{/each}}
 
 <button class = "new-post-btn" type="button">New Post!</button>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -31,7 +31,8 @@
       {{{body}}}
     </div>
   </main>
-
+  
+<script src="/js/dashboard.js"></script>
 <script src="/js/logout.js"></script>
 </body>
 

--- a/views/partials/blog-post-preview-dashboard.handlebars
+++ b/views/partials/blog-post-preview-dashboard.handlebars
@@ -2,5 +2,7 @@
   <header id="{{id}}">
     <a href="/post/{{id}}"><h2>{{title}}</h2></a>
     <p>Posted by {{user.username}} on {{format_date createdAt}}</p>
+    <button class="delete-post-btn btn btn-primary" type="button" style="background-color: red;">Delete</button>
   </header>
+
 </section>

--- a/views/partials/blog-post-preview-dashboard.handlebars
+++ b/views/partials/blog-post-preview-dashboard.handlebars
@@ -2,7 +2,7 @@
   <header id="{{id}}">
     <a href="/post/{{id}}"><h2>{{title}}</h2></a>
     <p>Posted by {{user.username}} on {{format_date createdAt}}</p>
-    <button class="delete-post-btn btn btn-primary" type="button" style="background-color: red;">Delete</button>
+    <button name="{{id}}" class="delete-post-btn btn btn-primary" type="button" style="background-color: red;">Delete</button>
   </header>
 
 </section>


### PR DESCRIPTION
- Wrote a new partial `blog-post-preview-dashboard.handlebars` that adds a delete button to the blog-post previews
- Wrote a new `dashboard.js` file that uses event delegation to provide a functional button to each blog post. 
    - Also, initiates a fetch request to DELETE the requested post
- In `blogRoutes.js`
    - Defined a new route to handle delete requests
        - Implements logic to prevent users from deleting posts they did not publish 
        - Returns a response if the provided post id is not within the database
- Imported `dashboard.js` into `main.handlebars`  